### PR TITLE
feat: Implement internationalization (i18n) for language switching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/about.html
+++ b/about.html
@@ -4,21 +4,43 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>About BioPixel</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
     <link rel="stylesheet" href="style.css">
+    <!-- It's possible style.css might conflict or be overridden by Bootstrap for some elements -->
 </head>
 <body>
-    <nav>
-        <ul>
-            <li><a href="index.html">Home</a></li>
-            <li><a href="about.html">About Us</a></li>
-        </ul>
+    <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
+      <div class="container">
+        <a class="navbar-brand fw-bold" href="index.html">Biopixel</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu" aria-controls="navMenu" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navMenu">
+          <ul class="navbar-nav ms-auto">
+            <li class="nav-item"><a class="nav-link" href="index.html" data-i18n="navbar_home">Home</a></li>
+            <li class="nav-item"><a class="nav-link active" href="about.html" data-i18n="navbar_about">About Us</a></li>
+            <li class="nav-item"><a class="nav-link" href="index.html#contacto" data-i18n="navbar_contact">Contact</a></li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                Idioma/Language
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="languageDropdown">
+                <li><a class="dropdown-item" href="#" onclick="setLanguage('es')">Español</a></li>
+                <li><a class="dropdown-item" href="#" onclick="setLanguage('en')">English</a></li>
+              </ul>
+            </li>
+          </ul>
+        </div>
+      </div>
     </nav>
-    <div class="container">
-        <h1>About BioPixel</h1>
-        <p>Biopixel is a company focused on transforming how large-scale agriculture is planned and managed. We aim to integrate data from diverse sources into a single system capable of offering models, simulations, and support tools for on-the-ground decision-making.</p>
-<p>We are founded on the conviction that value lies in understanding space and time in a coordinated manner, and that agricultural productivity can be optimized with reliable, accessible, and actionable information.</p>
-<p>Our approach combines technical knowledge, operational vision, and experience in spatial data management. We want to bring precision agriculture solutions closer, enabling improved efficiency, problem anticipation, and a foundational ordering of processes.</p>
-<p>Biopixel not only delivers technology: it proposes a new way of understanding the field, with a strategic perspective connected to the reality of those who work it.</p>
+    <div class="container mt-4"> <!-- Added mt-4 for some spacing below navbar -->
+        <h1 data-i18n="about_title">About BioPixel</h1>
+        <p data-i18n="about_p1">Biopixel is a company focused on transforming how large-scale agriculture is planned and managed. We aim to integrate data from diverse sources into a single system capable of offering models, simulations, and support tools for on-the-ground decision-making.</p>
+<p data-i18n="about_p2">We are founded on the conviction that value lies in understanding space and time in a coordinated manner, and that agricultural productivity can be optimized with reliable, accessible, and actionable information.</p>
+<p data-i18n="about_p3">Our approach combines technical knowledge, operational vision, and experience in spatial data management. We want to bring precision agriculture solutions closer, enabling improved efficiency, problem anticipation, and a foundational ordering of processes.</p>
+<p data-i18n="about_p4">Biopixel not only delivers technology: it proposes a new way of understanding the field, with a strategic perspective connected to the reality of those who work it.</p>
     </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="i18n.js"></script>
 </body>
 </html>

--- a/en.json
+++ b/en.json
@@ -1,0 +1,16 @@
+{
+  "navbar_home": "Home",
+  "navbar_about": "About Us",
+  "navbar_contact": "Contact",
+  "hero_title": "Transforming agriculture through data and technology",
+  "hero_subtitle1": "Large-scale agriculture today faces complex challenges: optimizing resources, anticipating risks, and making precise decisions in real-time. Biopixel was born to integrate all relevant information into a unified platform, facilitating efficient planning and management of crops and harvests.",
+  "hero_subtitle2": "Through advanced models, spatial mapping, and continuous monitoring, we offer tools that maximize productivity and reduce uncertainties at each stage of the agricultural process.",
+  "hero_subtitle3": "Our mission is to bring precision agriculture to any productive reality, delivering reliable, accessible solutions designed for those who live the field day by day.",
+  "hero_button": "Learn More",
+  "about_title": "About Us",
+  "about_p1": "Biopixel is a company focused on transforming how large-scale agriculture is planned and managed. We aim to integrate data from diverse sources into a single system capable of offering models, simulations, and support tools for on-the-ground decision-making.",
+  "about_p2": "We are founded on the conviction that value lies in understanding space and time in a coordinated manner, and that agricultural productivity can be optimized with reliable, accessible, and actionable information.",
+  "about_p3": "Our approach combines technical knowledge, operational vision, and experience in spatial data management. We want to bring precision agriculture solutions closer, enabling improved efficiency, problem anticipation, and a foundational ordering of processes.",
+  "about_p4": "Biopixel not only delivers technology: it proposes a new way of understanding the field, with a strategic perspective connected to the reality of those who work it.",
+  "footer_copyright": "© 2025 Biopixel. All rights reserved."
+}

--- a/es.json
+++ b/es.json
@@ -1,0 +1,16 @@
+{
+  "navbar_home": "Inicio",
+  "navbar_about": "Quiénes Somos",
+  "navbar_contact": "Contacto",
+  "hero_title": "Transformando la agricultura a través de datos y tecnología",
+  "hero_subtitle1": "La agricultura a gran escala enfrenta hoy desafíos complejos: optimizar recursos, anticipar riesgos y tomar decisiones precisas en tiempo real. Biopixel nace para integrar toda la información relevante en una plataforma unificada, facilitando la planificación y gestión eficiente de cultivos y cosechas.",
+  "hero_subtitle2": "Mediante modelos avanzados, mapeo espacial y monitoreo continuo, ofrecemos herramientas que permiten maximizar la productividad y reducir incertidumbres en cada etapa del proceso agrícola.",
+  "hero_subtitle3": "Nuestra misión es acercar la agricultura de precisión a cualquier realidad productiva, entregando soluciones confiables, accesibles y diseñadas para quienes viven el campo día a día.",
+  "hero_button": "Conócenos",
+  "about_title": "Quiénes somos",
+  "about_p1": "Biopixel es una empresa orientada a transformar la forma en que se planifica y gestiona la agricultura a gran escala. Buscamos integrar datos provenientes de diversas fuentes en un único sistema, capaz de ofrecer modelos, simulaciones y herramientas de apoyo para la toma de decisiones en terreno.",
+  "about_p2": "Nacemos con la convicción de que el valor está en entender el espacio y el tiempo de forma coordinada, y de que la productividad agrícola puede optimizarse si se cuenta con información confiable, accesible y accionable.",
+  "about_p3": "Nuestro enfoque combina conocimiento técnico, visión operativa y experiencia en manejo de datos espaciales. Queremos acercar soluciones de agricultura de precisión que permitan mejorar la eficiencia, anticipar problemas y ordenar los procesos desde la base.",
+  "about_p4": "Biopixel no solo entrega tecnología: propone una nueva forma de entender el campo, con una mirada estratégica y conectada a la realidad de quienes lo trabajan.",
+  "footer_copyright": "© 2025 Biopixel. Todos los derechos reservados."
+}

--- a/i18n.js
+++ b/i18n.js
@@ -1,0 +1,123 @@
+// Function to fetch translation files
+async function fetchTranslations(lang) {
+  const response = await fetch(`${lang}.json`);
+  if (!response.ok) {
+    throw new Error(`Failed to load ${lang}.json`);
+  }
+  return await response.json();
+}
+
+// Function to apply translations to the page
+function applyTranslations(translations) {
+  console.log('[i18n] Applying translations...');
+  try {
+    document.querySelectorAll('[data-i18n]').forEach(element => {
+      const key = element.getAttribute('data-i18n');
+      if (translations[key]) {
+        // Preserve child elements for elements like the hero button
+        if (element.children.length > 0 && (key === 'hero_button' || key === 'navbar_home' || key === 'navbar_about' || key === 'navbar_contact')) {
+            // For buttons or links, we might only want to change the text node
+            // This is a simple approach; more complex structures might need specific handling
+            let textNode = Array.from(element.childNodes).find(node => node.nodeType === Node.TEXT_NODE);
+            if (textNode) {
+                textNode.textContent = translations[key];
+            } else {
+                element.textContent = translations[key];
+            }
+        } else {
+          element.textContent = translations[key];
+        }
+      }
+    });
+    // Update the lang attribute of the HTML tag
+    document.documentElement.lang = currentLanguage;
+    console.log('[i18n] Translations applied. HTML lang set to:', currentLanguage);
+  } catch (e) {
+    console.error('[i18n] Error in applyTranslations:', e);
+    throw e; // Re-throw to be caught by initLanguage promise
+  }
+}
+
+// Function to set the language
+async function setLanguage(lang) {
+  console.log('[i18n] Setting language to:', lang);
+  try {
+    await Promise.resolve(); // Test await itself
+    console.log('[i18n] after test await in setLanguage');
+  } catch (e) {
+    console.error('[i18n] Error after test await in setLanguage', e);
+    throw e;
+  }
+  if (!['en', 'es'].includes(lang)) {
+    console.warn(`[i18n] Language ${lang} not supported. Defaulting to 'es'.`);
+    lang = 'es';
+  }
+  try {
+    localStorage.setItem('language', lang);
+    console.log('[i18n] localStorage.setItem attempted for', lang);
+  } catch (e) {
+    console.error('[i18n] Error during localStorage.setItem (continuing anyway):', e);
+    // Do not throw e, allow to continue
+  }
+  currentLanguage = lang; // Update global current language
+  console.log('[i18n] Fetching translations for:', lang);
+  const translations = await fetchTranslations(lang);
+  console.log('[i18n] Translations fetched for:', lang);
+  applyTranslations(translations);
+  console.log('[i18n] Language set to:', lang);
+}
+
+// Function to initialize language settings
+async function initLanguage() {
+  console.log('[i18n] Initializing language...');
+  let preferredLanguage = 'es'; // Default
+  try {
+    preferredLanguage = localStorage.getItem('language') || 'es';
+    console.log('[i18n] Preferred language from localStorage:', preferredLanguage);
+  } catch (e) {
+    console.error('[i18n] Error reading from localStorage (continuing with default "es"):', e);
+    // preferredLanguage remains 'es'
+  }
+
+  // Check if the HTML lang attribute is set and different, and if so, use it.
+  try {
+    const htmlLang = document.documentElement.lang;
+    console.log('[i18n] HTML lang attribute:', htmlLang);
+    if (htmlLang && ['en', 'es'].includes(htmlLang) && htmlLang !== preferredLanguage) {
+      preferredLanguage = htmlLang;
+      console.log('[i18n] Using HTML lang attribute as preferred language:', preferredLanguage);
+    }
+  } catch (e) {
+    console.error('[i18n] Error reading document.documentElement.lang (continuing with preferredLanguage):', e);
+  }
+
+  currentLanguage = preferredLanguage; // Set global current language
+  console.log('[i18n] Current language before setLanguage call:', currentLanguage);
+  try {
+    await setLanguage(preferredLanguage);
+    console.log('[i18n] initLanguage: setLanguage completed for', preferredLanguage);
+  } catch (error) {
+    console.error('[i18n] initLanguage: Error calling setLanguage:', error);
+    throw error; // Re-throw to be caught by the i18nInitialized promise
+  }
+}
+
+// Global variable for current language
+let currentLanguage = 'es';
+
+// Initialize language settings when the script loads
+// Expose a promise that resolves when initLanguage is done
+window.i18nInitialized = new Promise((resolve, reject) => {
+  document.addEventListener('DOMContentLoaded', async () => {
+    try {
+      await initLanguage();
+      resolve();
+    } catch (error) {
+      console.error("Error during i18n initialization:", error);
+      reject(error);
+    }
+  });
+});
+
+// Make setLanguage globally accessible for the onclick handlers in HTML
+window.setLanguage = setLanguage;

--- a/index.html
+++ b/index.html
@@ -65,48 +65,58 @@
       </button>
       <div class="collapse navbar-collapse" id="navMenu">
         <ul class="navbar-nav ms-auto">
-          <li class="nav-item"><a class="nav-link active" href="#home">Inicio</a></li>
-          <li class="nav-item"><a class="nav-link" href="#quienes-somos">Quiénes Somos</a></li>
-          <li class="nav-item"><a class="nav-link" href="#contacto">Contacto</a></li>
+          <li class="nav-item"><a class="nav-link active" href="#home" data-i18n="navbar_home">Inicio</a></li>
+          <li class="nav-item"><a class="nav-link" href="#quienes-somos" data-i18n="navbar_about">Quiénes Somos</a></li>
+          <li class="nav-item"><a class="nav-link" href="#contacto" data-i18n="navbar_contact">Contacto</a></li>
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+              Idioma/Language
+            </a>
+            <ul class="dropdown-menu" aria-labelledby="languageDropdown">
+              <li><a class="dropdown-item" href="#" onclick="setLanguage('es')">Español</a></li>
+              <li><a class="dropdown-item" href="#" onclick="setLanguage('en')">English</a></li>
+            </ul>
+          </li>
         </ul>
       </div>
     </div>
   </nav>
 
   <section id="home" class="hero">
-    <h1>Transformando la agricultura a través de datos y tecnología</h1>
-    <p>
+    <h1 data-i18n="hero_title">Transformando la agricultura a través de datos y tecnología</h1>
+    <p data-i18n="hero_subtitle1">
       La agricultura a gran escala enfrenta hoy desafíos complejos: optimizar recursos, anticipar riesgos y tomar decisiones precisas en tiempo real. Biopixel nace para integrar toda la información relevante en una plataforma unificada, facilitando la planificación y gestión eficiente de cultivos y cosechas.
     </p>
-    <p>
+    <p data-i18n="hero_subtitle2">
       Mediante modelos avanzados, mapeo espacial y monitoreo continuo, ofrecemos herramientas que permiten maximizar la productividad y reducir incertidumbres en cada etapa del proceso agrícola.
     </p>
-    <p>
+    <p data-i18n="hero_subtitle3">
       Nuestra misión es acercar la agricultura de precisión a cualquier realidad productiva, entregando soluciones confiables, accesibles y diseñadas para quienes viven el campo día a día.
     </p>
-    <a href="#quienes-somos" class="btn btn-primary btn-lg mt-4">Conócenos</a>
+    <a href="#quienes-somos" class="btn btn-primary btn-lg mt-4" data-i18n="hero_button">Conócenos</a>
   </section>
 
   <section id="quienes-somos" class="bg-white rounded shadow-sm">
-    <h2 class="mb-4 text-center">Quiénes somos</h2>
-    <p>
+    <h2 class="mb-4 text-center" data-i18n="about_title">Quiénes somos</h2>
+    <p data-i18n="about_p1">
       Biopixel es una empresa orientada a transformar la forma en que se planifica y gestiona la agricultura a gran escala. Buscamos integrar datos provenientes de diversas fuentes en un único sistema, capaz de ofrecer modelos, simulaciones y herramientas de apoyo para la toma de decisiones en terreno.
     </p>
-    <p>
+    <p data-i18n="about_p2">
       Nacemos con la convicción de que el valor está en entender el espacio y el tiempo de forma coordinada, y de que la productividad agrícola puede optimizarse si se cuenta con información confiable, accesible y accionable.
     </p>
-    <p>
+    <p data-i18n="about_p3">
       Nuestro enfoque combina conocimiento técnico, visión operativa y experiencia en manejo de datos espaciales. Queremos acercar soluciones de agricultura de precisión que permitan mejorar la eficiencia, anticipar problemas y ordenar los procesos desde la base.
     </p>
-    <p>
+    <p data-i18n="about_p4">
       Biopixel no solo entrega tecnología: propone una nueva forma de entender el campo, con una mirada estratégica y conectada a la realidad de quienes lo trabajan.
     </p>
   </section>
 
   <footer id="contacto">
-    <p>© 2025 Biopixel. Todos los derechos reservados.</p>
+    <p data-i18n="footer_copyright">© 2025 Biopixel. Todos los derechos reservados.</p>
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="i18n.js"></script>
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,463 @@
+{
+  "name": "app",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "jsdom": "^26.1.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
+      "integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
+      "integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^5.0.2",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.4.0.tgz",
+      "integrity": "sha512-W0Y2HOXlPkb2yaKrCVRjinYKciu/qSLEmK0K9mcfDei3zwlnHFEHAs/Du3cIRwPqY+J4JsiBzUjoHyc8RsJ03A==",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.5.0.tgz",
+      "integrity": "sha512-8vDa8Qxvr/+d94hSh5P3IJwI5t8/c0KsMp+g8bNw9cY2icONa5aPfvKeieW1WlG0WQYwwhJ7mjui2xtiePQSXw=="
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.20",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
+      "integrity": "sha512-/ieB+mDe4MrrKMT8z+mQL8klXydZWGR5Dowt4RAGKbJ3kIGEx3X4ljUo+6V73IXtUPWgfOlU5B9MlGxFO5T+cA=="
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "jsdom": "^26.1.0"
+  }
+}

--- a/run_test.js
+++ b/run_test.js
@@ -1,0 +1,118 @@
+const { JSDOM, VirtualConsole } = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+async function testI18n() {
+    console.log('--- Node.js JSDOM Test Runner ---');
+
+    // Read the HTML file
+    const testHtmlPath = path.resolve(__dirname, 'test_i18n.html');
+    let testHTML;
+    try {
+        testHTML = fs.readFileSync(testHtmlPath, 'utf-8');
+    } catch (e) {
+        console.error(`Failed to read test_i18n.html: ${e.message}`);
+        return;
+    }
+
+    // Read the i18n.js file to inject it
+    const i18nScriptPath = path.resolve(__dirname, 'i18n.js');
+    let i18nScriptContent;
+    try {
+        i18nScriptContent = fs.readFileSync(i18nScriptPath, 'utf-8');
+    } catch (e) {
+        console.error(`Failed to read i18n.js: ${e.message}`);
+        return;
+    }
+
+    // Fetch translation files for mocking
+    let enJSON, esJSON;
+    try {
+        enJSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'en.json'), 'utf-8'));
+        esJSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'es.json'), 'utf-8'));
+    } catch (e) {
+        console.error(`Failed to read JSON translation files: ${e.message}`);
+        return;
+    }
+
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("error", (...args) => console.error("JSDOM CONSOLE ERROR:", ...args));
+    virtualConsole.on("warn", (...args) => console.warn("JSDOM CONSOLE WARN:", ...args));
+    virtualConsole.on("info", (...args) => console.info("JSDOM CONSOLE INFO:", ...args));
+    virtualConsole.on("log", (...args) => console.log("JSDOM:", ...args));
+
+    try {
+        const dom = new JSDOM(testHTML, {
+            runScripts: "dangerously",
+            resources: "usable",
+            url: `file://${testHtmlPath}`,
+            virtualConsole,
+            beforeParse(window) {
+                window.addEventListener('unhandledrejection', event => {
+                    console.error('JSDOM UNHANDLED PROMISE REJECTION:', event.reason);
+                });
+
+                // Restore localStorage mock, making it slightly more Storage-like
+                const store = {};
+                window.localStorage = {
+                    getItem: function(key) {
+                        return store.hasOwnProperty(key) ? store[key] : null;
+                    },
+                    setItem: function(key, value) {
+                        store[key] = String(value);
+                    },
+                    removeItem: function(key) {
+                        delete store[key];
+                    },
+                    clear: function() {
+                        for (const key in store) {
+                            if (store.hasOwnProperty(key)) {
+                                delete store[key];
+                            }
+                        }
+                    },
+                    get length() {
+                        return Object.keys(store).length;
+                    },
+                    key: function(index) {
+                        const keys = Object.keys(store);
+                        return keys[index] || null;
+                    }
+                };
+
+                // Mock fetch to return local JSON files
+                window.fetch = async (url) => {
+                    // console.log(`JSDOM fetch mock: Intercepted request for ${url}`);
+                    const fileName = path.basename(url);
+                    if (fileName === 'en.json') {
+                        // console.log("JSDOM fetch mock: Serving en.json");
+                        return { ok: true, json: async () => JSON.parse(JSON.stringify(enJSON)) }; // Deep clone
+                    }
+                    if (fileName === 'es.json') {
+                        // console.log("JSDOM fetch mock: Serving es.json");
+                        return { ok: true, json: async () => JSON.parse(JSON.stringify(esJSON)) }; // Deep clone
+                    }
+                    console.error(`JSDOM fetch mock: Unknown URL: ${url}`);
+                    return { ok: false, status: 404, json: async () => ({ error: 'File not found' }) };
+                };
+
+                // JSDOM does not execute script tags with src directly in the way a browser does when dynamically created or complex loaded.
+                // We've read i18n.js, so we can directly evaluate it in the window context.
+                // This is simpler than trying to make JSDOM's resource loader work perfectly for this case.
+                // window.eval(i18nScriptContent);
+            }
+        });
+
+        // Wait for all scripts to load and execute, especially DOMContentLoaded and subsequent async operations
+        // The test_i18n.html script uses setTimeout to delay runTests. We need to allow that to trigger.
+        // A common way is to wait for a specific event or a timeout.
+        await new Promise(resolve => setTimeout(resolve, 1500)); // Increased timeout to ensure all async test operations complete
+
+        console.log('--- Node.js JSDOM Test Runner Finished ---');
+
+    } catch (error) {
+        console.error('Error during JSDOM execution:', error);
+    }
+}
+
+testI18n().catch(e => console.error("Critical error in testI18n:", e));

--- a/test_i18n.html
+++ b/test_i18n.html
@@ -1,0 +1,151 @@
+<!DOCTYPE html>
+<html lang="es"> <!-- Default to Spanish for initial state -->
+<head>
+    <meta charset="UTF-8">
+    <title>i18n Test</title>
+    <!-- Assuming bootstrap CSS is not strictly needed for this text content test -->
+</head>
+<body>
+    <nav class="navbar navbar-expand-md navbar-light bg-white shadow-sm">
+        <div class="container">
+          <a class="navbar-brand fw-bold" href="#">Biopixel Test</a>
+          <div class="collapse navbar-collapse" id="navMenu">
+            <ul class="navbar-nav ms-auto">
+              <li class="nav-item"><a class="nav-link active" href="#home" data-i18n="navbar_home">Inicio</a></li>
+              <li class="nav-item"><a class="nav-link" href="#quienes-somos" data-i18n="navbar_about">Quiénes Somos</a></li>
+              <li class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                  Idioma/Language
+                </a>
+                <ul class="dropdown-menu" aria-labelledby="languageDropdown">
+                  <li><a class="dropdown-item" href="#" onclick="setLanguage('es')">Español</a></li>
+                  <li><a class="dropdown-item" href="#" onclick="setLanguage('en')">English</a></li>
+                </ul>
+              </li>
+            </ul>
+          </div>
+        </div>
+    </nav>
+
+    <section id="home" class="hero">
+        <h1 data-i18n="hero_title">Título Inicial</h1>
+        <p data-i18n="hero_subtitle1">Subtítulo inicial.</p>
+        <a href="#quienes-somos" class="btn btn-primary btn-lg mt-4" data-i18n="hero_button">Botón Inicial</a>
+    </section>
+
+    <footer id="contacto">
+        <p data-i18n="footer_copyright">© 2025 Biopixel Test. Todos los derechos reservados.</p>
+    </footer>
+
+    <script src="i18n.js"></script>
+    <script>
+        async function runTests() {
+            console.log('--- Starting i18n tests ---');
+
+            // Fetch expected values for comparison
+            let enTranslations, esTranslations;
+            try {
+                const enResponse = await fetch('en.json');
+                enTranslations = await enResponse.json();
+                const esResponse = await fetch('es.json');
+                esTranslations = await esResponse.json();
+            } catch (error) {
+                console.error('Failed to load translation files for testing:', error);
+                return;
+            }
+
+            // Initial state check (should be Spanish due to html lang="es" and i18n.js default logic)
+            console.log('Initial document lang:', document.documentElement.lang);
+            let initialHeroTitle = document.querySelector('[data-i18n="hero_title"]').textContent;
+            console.log('Initial Hero title (should be Spanish via initLanguage):', initialHeroTitle);
+            if (initialHeroTitle !== esTranslations.hero_title) {
+                 console.error(`ERROR: Initial hero title mismatch. Expected: "${esTranslations.hero_title}", Got: "${initialHeroTitle}"`);
+            } else {
+                 console.log("SUCCESS: Initial hero title matches Spanish version.");
+            }
+            let initialNavHome = document.querySelector('[data-i18n="navbar_home"]').textContent;
+             console.log('Initial Navbar Home (should be Spanish):', initialNavHome);
+            if (initialNavHome !== esTranslations.navbar_home) {
+                console.error(`ERROR: Initial navbar_home mismatch. Expected: "${esTranslations.navbar_home}", Got: "${initialNavHome}"`);
+            } else {
+                console.log("SUCCESS: Initial navbar_home matches Spanish version.");
+            }
+
+
+            // Test setting to English
+            console.log('\n--- Setting language to English ---');
+            await window.setLanguage('en'); // Ensure global setLanguage is used
+            console.log('Document lang after setLanguage("en"):', document.documentElement.lang);
+            if (document.documentElement.lang !== 'en') console.error("ERROR: HTML lang attribute not updated to 'en'");
+            else console.log("SUCCESS: HTML lang attribute updated to 'en'");
+
+            const heroTitleEn = document.querySelector('[data-i18n="hero_title"]').textContent;
+            console.log('Hero title in English:', heroTitleEn);
+            if (heroTitleEn !== enTranslations.hero_title) {
+                console.error(`ERROR: English hero_title mismatch. Expected: "${enTranslations.hero_title}", Got: "${heroTitleEn}"`);
+            } else {
+                console.log("SUCCESS: English hero_title matches.");
+            }
+
+            const navHomeEn = document.querySelector('[data-i18n="navbar_home"]').textContent;
+            console.log('Navbar Home in English:', navHomeEn);
+             if (navHomeEn !== enTranslations.navbar_home) {
+                console.error(`ERROR: English navbar_home mismatch. Expected: "${enTranslations.navbar_home}", Got: "${navHomeEn}"`);
+            } else {
+                console.log("SUCCESS: English navbar_home matches.");
+            }
+
+            const heroButtonEn = document.querySelector('[data-i18n="hero_button"]').textContent;
+            console.log('Hero button in English:', heroButtonEn);
+            if (heroButtonEn !== enTranslations.hero_button) {
+                console.error(`ERROR: English hero_button mismatch. Expected: "${enTranslations.hero_button}", Got: "${heroButtonEn}"`);
+            } else {
+                console.log("SUCCESS: English hero_button matches.");
+            }
+
+            // Test setting back to Spanish
+            console.log('\n--- Setting language to Spanish ---');
+            await window.setLanguage('es');
+            console.log('Document lang after setLanguage("es"):', document.documentElement.lang);
+            if (document.documentElement.lang !== 'es') console.error("ERROR: HTML lang attribute not updated to 'es'");
+            else console.log("SUCCESS: HTML lang attribute updated to 'es'");
+
+            const heroTitleEs = document.querySelector('[data-i18n="hero_title"]').textContent;
+            console.log('Hero title in Spanish:', heroTitleEs);
+            if (heroTitleEs !== esTranslations.hero_title) {
+                console.error(`ERROR: Spanish hero_title mismatch. Expected: "${esTranslations.hero_title}", Got: "${heroTitleEs}"`);
+            } else {
+                console.log("SUCCESS: Spanish hero_title matches.");
+            }
+
+            const navHomeEs = document.querySelector('[data-i18n="navbar_home"]').textContent;
+            console.log('Navbar Home in Spanish:', navHomeEs);
+            if (navHomeEs !== esTranslations.navbar_home) {
+                console.error(`ERROR: Spanish navbar_home mismatch. Expected: "${esTranslations.navbar_home}", Got: "${navHomeEs}"`);
+            } else {
+                console.log("SUCCESS: Spanish navbar_home matches.");
+            }
+
+            console.log('\n--- i18n tests finished ---');
+        }
+
+        document.addEventListener('DOMContentLoaded', async () => {
+            console.log('Test script: DOMContentLoaded event fired.');
+            if (window.i18nInitialized) {
+                console.log('Test script: Waiting for i18nInitialized promise...');
+                try {
+                    await window.i18nInitialized;
+                    console.log('Test script: i18nInitialized promise resolved. Running tests.');
+                    await runTests();
+                } catch (error) {
+                    console.error('Test script: Error waiting for i18nInitialized or running tests:', error);
+                }
+            } else {
+                console.error('Test script: window.i18nInitialized promise not found. Cannot run tests.');
+                // Fallback to timeout if promise somehow isn't set, though it should be.
+                // setTimeout(runTests, 1000);
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
This commit introduces internationalization to the website, allowing you to switch between Spanish and English.

Key changes:
- Added `en.json` and `es.json` files to store language strings for English and Spanish respectively.
- Modified `index.html` and `about.html`:
    - Added `data-i18n` attributes to HTML elements for dynamic text replacement.
    - Included a language switcher dropdown in the navigation bar of both pages.
    - Refactored the navbar in `about.html` to be consistent with `index.html` and use Bootstrap.
- Created `i18n.js`:
    - Implements logic to fetch translation files based on selected language.
    - Updates text content of elements with `data-i18n` attributes.
    - Sets the `lang` attribute of the `<html>` tag.
    - Uses `localStorage` to persist language preference (with error handling for environments where localStorage might be restricted).
- I tested the language switching functionality using JSDOM, verifying text and lang attribute updates.