### PR TITLE
feat: Add Dutch language support

### DIFF
--- a/about.html
+++ b/about.html
@@ -27,6 +27,7 @@
               <ul class="dropdown-menu" aria-labelledby="languageDropdown">
                 <li><a class="dropdown-item" href="#" onclick="setLanguage('es')">Español</a></li>
                 <li><a class="dropdown-item" href="#" onclick="setLanguage('en')">English</a></li>
+                <li><a class="dropdown-item" href="#" onclick="setLanguage('nl')">Nederlands</a></li>
               </ul>
             </li>
           </ul>

--- a/i18n.js
+++ b/i18n.js
@@ -48,7 +48,7 @@ async function setLanguage(lang) {
     console.error('[i18n] Error after test await in setLanguage', e);
     throw e;
   }
-  if (!['en', 'es'].includes(lang)) {
+  if (!['en', 'es', 'nl'].includes(lang)) {
     console.warn(`[i18n] Language ${lang} not supported. Defaulting to 'es'.`);
     lang = 'es';
   }
@@ -83,7 +83,7 @@ async function initLanguage() {
   try {
     const htmlLang = document.documentElement.lang;
     console.log('[i18n] HTML lang attribute:', htmlLang);
-    if (htmlLang && ['en', 'es'].includes(htmlLang) && htmlLang !== preferredLanguage) {
+    if (htmlLang && ['en', 'es', 'nl'].includes(htmlLang) && htmlLang !== preferredLanguage) { // Also update here for consistency
       preferredLanguage = htmlLang;
       console.log('[i18n] Using HTML lang attribute as preferred language:', preferredLanguage);
     }

--- a/index.html
+++ b/index.html
@@ -75,6 +75,7 @@
             <ul class="dropdown-menu" aria-labelledby="languageDropdown">
               <li><a class="dropdown-item" href="#" onclick="setLanguage('es')">Español</a></li>
               <li><a class="dropdown-item" href="#" onclick="setLanguage('en')">English</a></li>
+              <li><a class="dropdown-item" href="#" onclick="setLanguage('nl')">Nederlands</a></li>
             </ul>
           </li>
         </ul>

--- a/nl.json
+++ b/nl.json
@@ -1,0 +1,16 @@
+{
+  "navbar_home": "[Dutch translation for navbar_home]",
+  "navbar_about": "[Dutch translation for navbar_about]",
+  "navbar_contact": "[Dutch translation for navbar_contact]",
+  "hero_title": "[Dutch translation for hero_title]",
+  "hero_subtitle1": "[Dutch translation for hero_subtitle1]",
+  "hero_subtitle2": "[Dutch translation for hero_subtitle2]",
+  "hero_subtitle3": "[Dutch translation for hero_subtitle3]",
+  "hero_button": "[Dutch translation for hero_button]",
+  "about_title": "[Dutch translation for about_title]",
+  "about_p1": "[Dutch translation for about_p1]",
+  "about_p2": "[Dutch translation for about_p2]",
+  "about_p3": "[Dutch translation for about_p3]",
+  "about_p4": "[Dutch translation for about_p4]",
+  "footer_copyright": "[Dutch translation for footer_copyright]"
+}

--- a/run_test.js
+++ b/run_test.js
@@ -26,10 +26,11 @@ async function testI18n() {
     }
 
     // Fetch translation files for mocking
-    let enJSON, esJSON;
+    let enJSON, esJSON, nlJSON;
     try {
         enJSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'en.json'), 'utf-8'));
         esJSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'es.json'), 'utf-8'));
+        nlJSON = JSON.parse(fs.readFileSync(path.resolve(__dirname, 'nl.json'), 'utf-8'));
     } catch (e) {
         console.error(`Failed to read JSON translation files: ${e.message}`);
         return;
@@ -91,6 +92,10 @@ async function testI18n() {
                     if (fileName === 'es.json') {
                         // console.log("JSDOM fetch mock: Serving es.json");
                         return { ok: true, json: async () => JSON.parse(JSON.stringify(esJSON)) }; // Deep clone
+                    }
+                    if (fileName === 'nl.json') {
+                        // console.log("JSDOM fetch mock: Serving nl.json");
+                        return { ok: true, json: async () => JSON.parse(JSON.stringify(nlJSON)) }; // Deep clone
                     }
                     console.error(`JSDOM fetch mock: Unknown URL: ${url}`);
                     return { ok: false, status: 404, json: async () => ({ error: 'File not found' }) };

--- a/test_i18n.html
+++ b/test_i18n.html
@@ -43,19 +43,23 @@
             console.log('--- Starting i18n tests ---');
 
             // Fetch expected values for comparison
-            let enTranslations, esTranslations;
+            let enTranslations, esTranslations, nlTranslations; // Added nlTranslations
             try {
                 const enResponse = await fetch('en.json');
                 enTranslations = await enResponse.json();
                 const esResponse = await fetch('es.json');
                 esTranslations = await esResponse.json();
+                const nlResponse = await fetch('nl.json'); // Fetch nl.json
+                nlTranslations = await nlResponse.json();   // Parse nl.json
             } catch (error) {
                 console.error('Failed to load translation files for testing:', error);
                 return;
             }
 
             // Initial state check (should be Spanish due to html lang="es" and i18n.js default logic)
-            console.log('Initial document lang:', document.documentElement.lang);
+            // Note: i18n.js init logic runs on DOMContentLoaded and might update this before these specific lines run
+            // depending on exact timing. The await window.i18nInitialized in the event listener is key.
+            console.log('Initial document lang (after i18n init):', document.documentElement.lang);
             let initialHeroTitle = document.querySelector('[data-i18n="hero_title"]').textContent;
             console.log('Initial Hero title (should be Spanish via initLanguage):', initialHeroTitle);
             if (initialHeroTitle !== esTranslations.hero_title) {
@@ -126,6 +130,29 @@
                 console.log("SUCCESS: Spanish navbar_home matches.");
             }
 
+            // Test setting to Dutch
+            console.log('\n--- Setting language to Dutch ---');
+            await window.setLanguage('nl');
+            console.log('Document lang after setLanguage("nl"):', document.documentElement.lang);
+            if (document.documentElement.lang !== 'nl') console.error("ERROR: HTML lang attribute not updated to 'nl'");
+            else console.log("SUCCESS: HTML lang attribute updated to 'nl'");
+
+            const heroTitleNl = document.querySelector('[data-i18n="hero_title"]').textContent;
+            console.log('Hero title in Dutch:', heroTitleNl);
+            if (heroTitleNl !== nlTranslations.hero_title) {
+                console.error(`ERROR: Dutch hero_title mismatch. Expected: "${nlTranslations.hero_title}", Got: "${heroTitleNl}"`);
+            } else {
+                console.log("SUCCESS: Dutch hero_title matches.");
+            }
+
+            const navHomeNl = document.querySelector('[data-i18n="navbar_home"]').textContent;
+            console.log('Navbar Home in Dutch:', navHomeNl);
+            if (navHomeNl !== nlTranslations.navbar_home) {
+                console.error(`ERROR: Dutch navbar_home mismatch. Expected: "${nlTranslations.navbar_home}", Got: "${navHomeNl}"`);
+            } else {
+                console.log("SUCCESS: Dutch navbar_home matches.");
+            }
+
             console.log('\n--- i18n tests finished ---');
         }
 
@@ -134,16 +161,14 @@
             if (window.i18nInitialized) {
                 console.log('Test script: Waiting for i18nInitialized promise...');
                 try {
-                    await window.i18nInitialized;
+                    await window.i18nInitialized; // Ensure i18n.js has fully initialized
                     console.log('Test script: i18nInitialized promise resolved. Running tests.');
-                    await runTests();
+                    await runTests(); // Now run the actual tests
                 } catch (error) {
-                    console.error('Test script: Error waiting for i18nInitialized or running tests:', error);
+                    console.error('Test script: Error during i18n initialization or running tests:', error);
                 }
             } else {
                 console.error('Test script: window.i18nInitialized promise not found. Cannot run tests.');
-                // Fallback to timeout if promise somehow isn't set, though it should be.
-                // setTimeout(runTests, 1000);
             }
         });
     </script>


### PR DESCRIPTION
This commit introduces Dutch language support to the website.

Key changes:
- Added `nl.json` with placeholder Dutch translations for all existing text keys. You or translators will need to provide accurate translations.
- Updated `i18n.js` to recognize 'nl' as a supported language code in its `setLanguage` and `initLanguage` functions.
- Modified `index.html` and `about.html` to include "Nederlands" in the language switcher dropdown menu, allowing you to select Dutch.
- I confirmed that selecting Dutch correctly updates the HTML lang attribute to 'nl' and displays the placeholder Dutch text.