### PR TITLE
Add viewport meta tag for proper mobile responsiveness

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
       href="https://fonts.googleapis.com/css2?display=swap&amp;family=Noto+Sans%3Awght%40400%3B500%3B700%3B900&amp;family=Space+Grotesk%3Awght%40400%3B500%3B700"
     />
 
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title data-i18n="new_page_title">Stitch Design</title>
     <link rel="icon" type="image/x-icon" href="data:image/x-icon;base64," />
 


### PR DESCRIPTION
Added `<meta name="viewport" content="width=device-width, initial-scale=1.0">` to index.html to ensure correct scaling and breakpoint activation on mobile devices. This is expected to resolve issues where the site did not adapt to mobile screen sizes and the hamburger menu did not appear as intended on actual mobile devices or specific device emulations.